### PR TITLE
Pass parameters by reference and make them const

### DIFF
--- a/DX12Engine/Buffers.cpp
+++ b/DX12Engine/Buffers.cpp
@@ -7,7 +7,7 @@ ComPtr<ID3D12Resource> createDefaultHeapBuffer(
 	ID3D12Device* device,
 	ID3D12GraphicsCommandList* cmdList,
 	const void* initData,
-	UINT64 byteSize,
+	const UINT64 byteSize,
 	ComPtr<ID3D12Resource>& uploadBuffer)
 {
 	// Create the default heap buffer
@@ -64,7 +64,7 @@ GPUHeapUploader::GPUHeapUploader(ComPtr<ID3D12Device> device, ComPtr<ID3D12Comma
 	ThrowIfFailed(m_device->CreateFence(0, D3D12_FENCE_FLAG_NONE, IID_PPV_ARGS(&m_fence)), "Cannot create fence");
 }
 
-ComPtr<ID3D12Resource> GPUHeapUploader::Upload(const void* initData, UINT64 byteSize)
+ComPtr<ID3D12Resource> GPUHeapUploader::Upload(const void* initData, const UINT64 byteSize)
 {
 	ThrowIfFailed(m_commandListAlloc->Reset(), "Cannot reset allocator");
 	ThrowIfFailed(m_commandList->Reset(m_commandListAlloc.Get(), nullptr), "Cannot reset command list");

--- a/DX12Engine/Buffers.h
+++ b/DX12Engine/Buffers.h
@@ -27,7 +27,7 @@ Microsoft::WRL::ComPtr<ID3D12Resource> createDefaultHeapBuffer(
 	ID3D12Device* device,
 	ID3D12GraphicsCommandList* cmdList,
 	const void* initData,
-	UINT64 byteSize,
+	const UINT64 byteSize,
 	Microsoft::WRL::ComPtr<ID3D12Resource>& uploadBuffer);
 
 /** Helper class to upload data to GPU DEFAULT HEAP synchronously */
@@ -35,7 +35,7 @@ class GPUHeapUploader
 {
 public:
 	GPUHeapUploader(Microsoft::WRL::ComPtr<ID3D12Device> device, Microsoft::WRL::ComPtr<ID3D12CommandQueue> commandQueue);
-	Microsoft::WRL::ComPtr<ID3D12Resource> Upload(const void* initData, UINT64 byteSize);
+	Microsoft::WRL::ComPtr<ID3D12Resource> Upload(const void* initData, const UINT64 byteSize);
 
 private:
 	Microsoft::WRL::ComPtr<ID3D12CommandAllocator> m_commandListAlloc;
@@ -54,17 +54,17 @@ template <class T>
 class UploadBuffer
 {
 public:
-	UploadBuffer(ID3D12Device* device, UINT count, bool isConstant);
+	UploadBuffer(ID3D12Device* device, const UINT count, const bool isConstant);
 	UploadBuffer(const UploadBuffer&) = delete;
 	UploadBuffer& operator=(const UploadBuffer&) = delete;
 	~UploadBuffer();
 
 	ID3D12Resource* getResource() const;
 	void release();
-	void copyData(int index, const T& data);
+	void copyData(const int index, const T& data);
 
 protected:
-	virtual void createBuffer(ID3D12Device* device, UINT count, bool isConstant);
+	virtual void createBuffer(ID3D12Device* device, const UINT count, const bool isConstant);
 
 	Microsoft::WRL::ComPtr<ID3D12Resource> m_buffer;	/*< Com pointer to the buffer */
 	std::size_t m_elementByteSize;						/*< The byte size of an element in the buffer */
@@ -72,7 +72,7 @@ protected:
 };
 
 template <class T>
-UploadBuffer<T>::UploadBuffer(ID3D12Device* device, UINT count, bool isConstant)
+UploadBuffer<T>::UploadBuffer(ID3D12Device* device, const UINT count, const bool isConstant)
 {
 	createBuffer(device, count, isConstant);
 }
@@ -97,7 +97,7 @@ void UploadBuffer<T>::release()
 }
 
 template <class T>
-void UploadBuffer<T>::createBuffer(ID3D12Device* device, UINT count, bool isConstant)
+void UploadBuffer<T>::createBuffer(ID3D12Device* device, const UINT count, const bool isConstant)
 {
 	if (isConstant)
 	{
@@ -124,7 +124,7 @@ ID3D12Resource* UploadBuffer<T>::getResource() const
 }
 
 template <class T>
-void UploadBuffer<T>::copyData(int index, const T& data)
+void UploadBuffer<T>::copyData(const int index, const T& data)
 {
 	memcpy(&m_data[index * m_elementByteSize], &data, sizeof(T));
 }

--- a/DX12Engine/Camera.cpp
+++ b/DX12Engine/Camera.cpp
@@ -5,7 +5,7 @@ using DirectX::XMFLOAT4X4;
 using DirectX::XMVECTOR;
 using DirectX::XMMATRIX;
 
-Camera::Camera(UINT32 width, UINT32 height, float fovY, float nearZ, float farZ) :
+Camera::Camera(const UINT32 width, const UINT32 height, const float fovY, const float nearZ, const float farZ) :
 	m_width(width), m_height(height), m_dirty(false)
 {
 	m_position = { 0.0f, 0.0f, 0.0f };
@@ -25,7 +25,7 @@ Camera::Camera(UINT32 width, UINT32 height, float fovY, float nearZ, float farZ)
 Camera::~Camera()
 {}
 
-void Camera::setLens(float fovY, float aspectRatio, float nearZ, float farZ)
+void Camera::setLens(const float fovY, const float aspectRatio, const float nearZ, const float farZ)
 {
 	m_fovY = fovY;
 	m_aspectRatio = aspectRatio;
@@ -52,7 +52,7 @@ DirectX::XMFLOAT3 Camera::GetPosition()  const
 	return m_position;
 }
 
-void Camera::moveForward(float distance)
+void Camera::moveForward(const float distance)
 {
 	XMVECTOR forward = XMLoadFloat3(&m_forward);
 	XMVECTOR position = XMLoadFloat3(&m_position);
@@ -60,7 +60,7 @@ void Camera::moveForward(float distance)
 	m_dirty = true;
 }
 
-void Camera::strafe(float distance)
+void Camera::strafe(const float distance)
 {
 	XMVECTOR right = XMLoadFloat3(&m_right);
 	XMVECTOR position = XMLoadFloat3(&m_position);
@@ -68,7 +68,7 @@ void Camera::strafe(float distance)
 	m_dirty = true;
 }
 
-void Camera::rotate(float pitch, float worldUpAngle)
+void Camera::rotate(const float pitch, const float worldUpAngle)
 {
 	XMMATRIX pitchRotMtx = DirectX::XMMatrixRotationAxis(XMLoadFloat3(&m_right), pitch);
 	XMStoreFloat3(&m_up, DirectX::XMVector3TransformNormal(XMLoadFloat3(&m_up), pitchRotMtx));

--- a/DX12Engine/Camera.h
+++ b/DX12Engine/Camera.h
@@ -17,25 +17,25 @@ class Camera
 public:
 
 	/** Constructor */
-	Camera(UINT32 width, UINT32 height, float fovY, float nearZ, float farZ);
+	Camera(const UINT32 width, const UINT32 height, const float fovY, const float nearZ, const float farZ);
 
 	/** Destructor */
 	~Camera();
 
 	/** Set camera lens */
-	void setLens(float fovY, float aspect, float nearZ, float farZ);
+	void setLens(const float fovY, const float aspect, const float nearZ, const float farZ);
 
 	/** Set camera position */
 	void setPosition(DirectX::XMFLOAT3 position);
 
 	/** Move the camera in the forward direction */
-	void moveForward(float distance);
+	void moveForward(const float distance);
 	
 	/** Strafe: move the camera in the camera right direction */
-	void strafe(float distance);
+	void strafe(const float distance);
 	
 	/** Rotate the camera around the right camera vector (pitch) or the world up axis. Angles are in radians */
-	void rotate(float pitch, float worldUpAngle);
+	void rotate(const float pitch, const float worldUpAngle);
 
 	/** Set up camera position and direction */
 	void lookAt(const DirectX::XMFLOAT3& position, const DirectX::XMFLOAT3& target, const DirectX::XMFLOAT3& worldUp);

--- a/DX12Engine/DXUtil.cpp
+++ b/DX12Engine/DXUtil.cpp
@@ -42,7 +42,7 @@ namespace DXUtil
 		return outputList;
 	}
 
-	std::vector<DXGI_MODE_DESC> enumerateAdapterOutputDisplayModes(IDXGIOutput* output, DXGI_FORMAT format)
+	std::vector<DXGI_MODE_DESC> enumerateAdapterOutputDisplayModes(IDXGIOutput* output, const DXGI_FORMAT format)
 	{
 		UINT count = 0;
 		UINT flags = 0;		// This flag specifies modes to include in the list, 0 = 
@@ -79,7 +79,7 @@ namespace DXUtil
 	}
 
 
-	UINT PadByteSizeTo256Mul(UINT byteSize)
+	UINT PadByteSizeTo256Mul(const UINT byteSize)
 	{
 		return (byteSize + 255) & ~255;
 	}

--- a/DX12Engine/DXUtil.h
+++ b/DX12Engine/DXUtil.h
@@ -102,13 +102,13 @@ namespace DXUtil
     std::vector<Microsoft::WRL::ComPtr<IDXGIOutput>>  enumerateAdaptersOutputs(IDXGIAdapter* adapter);
 
     /** Enumerate all the display modes supported from an output device */
-    std::vector<DXGI_MODE_DESC> enumerateAdapterOutputDisplayModes(IDXGIOutput* output, DXGI_FORMAT format);
+    std::vector<DXGI_MODE_DESC> enumerateAdapterOutputDisplayModes(IDXGIOutput* output, const DXGI_FORMAT format);
 
     /** Print out adapter info */
     void printAdaptersInfo();
 
     /** Compute the byte size of a buffer after padding it to a 256 byte multiple */
-    UINT PadByteSizeTo256Mul(UINT byteSize);
+    UINT PadByteSizeTo256Mul(const UINT byteSize);
 
     /* Store an indentity matmrix in a XMFLOAT4X4 */
     DirectX::XMFLOAT4X4 IdentityMtx();

--- a/DX12Engine/DrawableAsset.cpp
+++ b/DX12Engine/DrawableAsset.cpp
@@ -1,6 +1,6 @@
 #include "DrawableAsset.h"
 
-void DrawableAsset::AddGPUBuffer(Microsoft::WRL::ComPtr<ID3D12Resource> buffer)
+void DrawableAsset::AddGPUBuffer(const Microsoft::WRL::ComPtr<ID3D12Resource>& buffer)
 {
 	m_buffersGPU.push_back(buffer);
 }

--- a/DX12Engine/DrawableAsset.h
+++ b/DX12Engine/DrawableAsset.h
@@ -6,11 +6,11 @@
 class DrawableAsset
 {
 public:
-	virtual void AddGPUBuffer(Microsoft::WRL::ComPtr<ID3D12Resource> buffer);
-	virtual Microsoft::WRL::ComPtr<ID3DBlob> GetVertexShader() = 0;
-	virtual Microsoft::WRL::ComPtr<ID3DBlob> GetPixelShader() = 0;
-	virtual	Microsoft::WRL::ComPtr<ID3D12RootSignature> GetRootSignature() = 0;
-	virtual void Draw(ID3D12GraphicsCommandList* commandList) = 0;
+	virtual void AddGPUBuffer(const Microsoft::WRL::ComPtr<ID3D12Resource>& buffer);
+	virtual Microsoft::WRL::ComPtr<ID3DBlob> GetVertexShader() const = 0;
+	virtual Microsoft::WRL::ComPtr<ID3DBlob> GetPixelShader() const = 0;
+	virtual	Microsoft::WRL::ComPtr<ID3D12RootSignature> GetRootSignature() = 0;		//Should be const conceptually
+	virtual void Draw(ID3D12GraphicsCommandList* commandList) = 0;					//Should be const conceptually
 
 protected:
 	virtual void SetUpRootSignature(ID3D12GraphicsCommandList* commandList) = 0;

--- a/DX12Engine/GLTFSceneLoader.h
+++ b/DX12Engine/GLTFSceneLoader.h
@@ -15,7 +15,7 @@ public:
 	 * Loads the model information from the glTF file filename, to load a scene from the model call GetScene
 	 * @param fileName the .gltf or .glb file to load
 	 */
-	void Load(std::string fileName);
+	void Load(const std::string& fileName);
 	
 	/** 
 	  * Load a scene from the glTF file into the Scene object 

--- a/DX12Engine/Grid.cpp
+++ b/DX12Engine/Grid.cpp
@@ -13,7 +13,7 @@ D3D12_INPUT_ELEMENT_DESC gridVertexElementsDesc[] =
 
 Grid::~Grid() {}
 
-void Grid::Init(ComPtr<ID3D12Device> device, ComPtr<ID3D12CommandQueue> commandQueue, float halfSize)
+void Grid::Init(ComPtr<ID3D12Device> device, ComPtr<ID3D12CommandQueue> commandQueue, const float halfSize)
 {
     m_device = device;
     m_commandQueue = commandQueue;
@@ -37,12 +37,12 @@ void Grid::Init(ComPtr<ID3D12Device> device, ComPtr<ID3D12CommandQueue> commandQ
         "Cannot create CBV SRV UAV descriptor heap");
 }
 
-ComPtr<ID3DBlob> Grid::GetVertexShader()
+ComPtr<ID3DBlob> Grid::GetVertexShader() const
 {
     return m_vertexShader;
 }
 
-ComPtr<ID3DBlob> Grid::GetPixelShader()
+ComPtr<ID3DBlob> Grid::GetPixelShader() const
 {
     return m_pixelShader;
 }
@@ -77,13 +77,13 @@ void Grid::SetCamera(const Camera& camera)
     m_frameConstantsBuffer->copyData(0, m_frameConstants);
 }
 
-void Grid::SetFrameConstants(FrameConstants frameConstants)
+void Grid::SetFrameConstants(const FrameConstants& frameConstants)
 {
     m_frameConstants = frameConstants;
     m_frameConstantsBuffer->copyData(0, frameConstants);
 }
 
-void Grid::SetGridConstants(GridConstants gridConstants)
+void Grid::SetGridConstants(const GridConstants& gridConstants)
 {
     m_gridConstants = gridConstants;
     m_gridConstantsBuffer->copyData(0, gridConstants);
@@ -116,7 +116,7 @@ void Grid::Draw(ID3D12GraphicsCommandList* commandList)
     commandList->DrawInstanced(m_verticesBufferView.count, 1, 0, 0);
 }
 
-void Grid::GenerateGrid(float halfSide)
+void Grid::GenerateGrid(const float halfSide)
 {
     float step = halfSide / 5.0f;
 

--- a/DX12Engine/Grid.h
+++ b/DX12Engine/Grid.h
@@ -17,17 +17,17 @@ class Grid : public DrawableAsset
 {
 public:
 	~Grid();
-	void Init(Microsoft::WRL::ComPtr<ID3D12Device> device, Microsoft::WRL::ComPtr<ID3D12CommandQueue> commandQueue, float halfSize);
-	Microsoft::WRL::ComPtr<ID3DBlob> GetVertexShader();
-	Microsoft::WRL::ComPtr<ID3DBlob> GetPixelShader();
-	Microsoft::WRL::ComPtr<ID3D12RootSignature> GetRootSignature();
+	void Init(Microsoft::WRL::ComPtr<ID3D12Device> device, Microsoft::WRL::ComPtr<ID3D12CommandQueue> commandQueue, const float halfSize);
+	Microsoft::WRL::ComPtr<ID3DBlob> GetVertexShader() const override;
+	Microsoft::WRL::ComPtr<ID3DBlob> GetPixelShader() const override;
+	Microsoft::WRL::ComPtr<ID3D12RootSignature> GetRootSignature() override;
 	void SetCamera(const Camera& camera);
-	void SetFrameConstants(FrameConstants frameConstants);
-	void SetGridConstants(GridConstants meshConstants);
-	void Draw(ID3D12GraphicsCommandList* commandList);
+	void SetFrameConstants(const FrameConstants& frameConstants);
+	void SetGridConstants(const GridConstants& meshConstants);
+	void Draw(ID3D12GraphicsCommandList* commandList) override;
 
 protected:
-	void GenerateGrid(float side);
+	void GenerateGrid(const float side);
 	void SetUpRootSignature(ID3D12GraphicsCommandList* commandList);
 
 	BufferView m_verticesBufferView;

--- a/DX12Engine/Gui.cpp
+++ b/DX12Engine/Gui.cpp
@@ -67,22 +67,22 @@ void Gui::Draw()
     ImGui_ImplDX12_RenderDrawData(ImGui::GetDrawData(), m_renderer->GetCommandList().Get());
 }
 
-void Gui::SetVsCompileErrorMsg(std::string errorMsg)
+void Gui::SetVsCompileErrorMsg(const std::string& errorMsg) noexcept
 {
     m_vsCompileErrorMsg = errorMsg;
 }
 
-void Gui::SetGsCompileErrorMsg(std::string errorMsg)
+void Gui::SetGsCompileErrorMsg(const std::string& errorMsg) noexcept
 {
     m_gsCompileErrorMsg = errorMsg;
 }
 
-void Gui::SetPsCompileErrorMsg(std::string errorMsg)
+void Gui::SetPsCompileErrorMsg(const std::string& errorMsg) noexcept
 {
     m_psCompileErrorMsg = errorMsg;
 }
 
-void Gui::ReSize(unsigned int width, unsigned int height)
+void Gui::ReSize(const unsigned int width, const unsigned int height)
 {
     if (!m_isInitialized) return;
     //ImGui_ImplDX12_InvalidateDeviceObjects();

--- a/DX12Engine/Gui.h
+++ b/DX12Engine/Gui.h
@@ -24,13 +24,13 @@ public:
 
     void Init(std::shared_ptr<Renderer> renderer, AppState* appState);
     void Draw();
-    void ReSize(unsigned int widht, unsigned int height);
+    void ReSize(const unsigned int widht, const unsigned int height);
     bool WantCaptureMouse();
     bool WantCaptureKeyboard();
     void ShutDown();
-    void SetVsCompileErrorMsg(std::string errorMsg);
-    void SetGsCompileErrorMsg(std::string errorMsg);
-    void SetPsCompileErrorMsg(std::string errorMsg);
+    void SetVsCompileErrorMsg(const std::string& errorMsg) noexcept;
+    void SetGsCompileErrorMsg(const std::string& errorMsg) noexcept;
+    void SetPsCompileErrorMsg(const std::string& errorMsg) noexcept;
 
 private:
     static constexpr int FRAME_RATE_SERIES_SIZE = 15;

--- a/DX12Engine/Mesh.cpp
+++ b/DX12Engine/Mesh.cpp
@@ -22,7 +22,7 @@ Mesh::Mesh()
 	constants.modelMtx = DXUtil::IdentityMtx();
 }
 
-void Mesh::SetId(unsigned int id)
+void Mesh::SetId(const unsigned int id)
 {
 	m_id = id;
 }
@@ -42,7 +42,7 @@ void Mesh::SetNodeMtx(const DirectX::XMFLOAT4X4& nodeMtx)
 	constants.nodeTransformMtx = nodeMtx;
 }
 
-void Mesh::AddSubMesh(const SubMesh& subMesh)
+void Mesh::AddSubMesh(const SubMesh&& subMesh)
 {
 	m_subMeshes.push_back(subMesh);
 }

--- a/DX12Engine/Mesh.h
+++ b/DX12Engine/Mesh.h
@@ -38,11 +38,11 @@ public:
 	Mesh(const Mesh& mesh) = default;
 	Mesh& operator=(const Mesh& mesh) = default;
 	
-	void SetId(unsigned int id);
+	void SetId(const unsigned int id);
 	unsigned int GetId() const;
 	void SetModelMtx(const DirectX::XMFLOAT4X4& modelMtx);
 	void SetNodeMtx(const DirectX::XMFLOAT4X4& nodeMtx); // A model transformation defined as the default position of the mesh in the world
-	void AddSubMesh(const SubMesh& subMesh);
+	void AddSubMesh(const SubMesh&& subMesh);
 
 	friend void Scene::DrawMesh(const Mesh& mesh, ID3D12GraphicsCommandList* commandList);
 	MeshConstants constants;

--- a/DX12Engine/Renderer.cpp
+++ b/DX12Engine/Renderer.cpp
@@ -8,7 +8,7 @@
 using Microsoft::WRL::ComPtr;
 using DXUtil::ThrowIfFailed;
 
-void Renderer::Init(HWND hWnd, unsigned int width, unsigned int height)
+void Renderer::Init(HWND hWnd, const unsigned int width, const unsigned int height)
 {
     DEBUG_LOG("Initializing Renderer object")
     m_hWnd = hWnd;
@@ -29,7 +29,7 @@ void Renderer::Init(HWND hWnd, unsigned int width, unsigned int height)
     //CreatePipelineState();
 }
 
-void Renderer::SetSize(unsigned int width, unsigned int height)
+void Renderer::SetSize(const unsigned int width, const unsigned int height)
 {
     FlushCommandQueue();
     m_width = width;
@@ -40,17 +40,17 @@ void Renderer::SetSize(unsigned int width, unsigned int height)
     CreateDepthStencilBuffer();
 }
 
-void Renderer::SetViewport(D3D12_VIEWPORT viewPort)
+void Renderer::SetViewport(const D3D12_VIEWPORT viewPort)
 {
     m_viewPort = viewPort;
 }
 
-void Renderer::SetScissorRect(D3D12_RECT scissorRect)
+void Renderer::SetScissorRect(const D3D12_RECT scissorRect)
 {
     m_scissorRect = scissorRect;
 }
 
-void Renderer::SetFullScreen(bool fullScreen)
+void Renderer::SetFullScreen(const bool fullScreen)
 {
     m_swapChain.SetFullScreen(fullScreen);
 }
@@ -265,7 +265,7 @@ void Renderer::CreateConstantBuffer()
         */
 }
 
-bool Renderer::CompileShaders(std::wstring fileName, std::string& errorMsg)
+bool Renderer::CompileShaders(const std::wstring& fileName, std::string& errorMsg)
 {
 #if defined(_DEBUG)
     UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
@@ -295,7 +295,7 @@ bool Renderer::CompileShaders(std::wstring fileName, std::string& errorMsg)
     return true;
 }
 
-bool Renderer::CompileVertexShader(std::wstring vsFileName, std::string& errorMsg)
+bool Renderer::CompileVertexShader(const std::wstring& vsFileName, std::string& errorMsg)
 {
 #if defined(_DEBUG)
     UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
@@ -316,12 +316,12 @@ bool Renderer::CompileVertexShader(std::wstring vsFileName, std::string& errorMs
         return true;
 }
 
-bool Renderer::CompileGeometryShader(std::wstring vsFileName, std::string& errorMsg) 
+bool Renderer::CompileGeometryShader(const std::wstring& vsFileName, std::string& errorMsg) 
 {
     return true;
 }
 
-bool Renderer::CompilePixelShader(std::wstring psFileName, std::string& errorMsg)
+bool Renderer::CompilePixelShader(const std::wstring& psFileName, std::string& errorMsg)
 {
 #if defined(_DEBUG)
     UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
@@ -417,7 +417,7 @@ void Renderer::CreatePipelineState(SkyBox* skyBox)
     ThrowIfFailed(m_device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&m_pipelineStateSky)), "Cannot create the pipeline state");
 }
 
-void Renderer::CreatePipelineState(Scene* scene, bool wireFrame)
+void Renderer::CreatePipelineState(Scene* scene, const bool wireFrame)
 {
     D3D12_INPUT_LAYOUT_DESC inputLayoutDesc;
     inputLayoutDesc.pInputElementDescs = vertexElementsDesc;

--- a/DX12Engine/Renderer.h
+++ b/DX12Engine/Renderer.h
@@ -35,11 +35,11 @@ public:
     Renderer operator=(const Renderer&) = delete;
     Renderer operator=(const Renderer&&) = delete;
 
-    void Init(HWND hWnd, unsigned int width, unsigned int height);
-    void SetSize(unsigned int width, unsigned int height);
-    void SetViewport(D3D12_VIEWPORT viewPort);
-    void SetScissorRect(D3D12_RECT scissorRect);
-    void SetFullScreen(bool fullScreen);
+    void Init(HWND hWnd, const unsigned int width, const unsigned int height);
+    void SetSize(const unsigned int width, const unsigned int height);
+    void SetViewport(const D3D12_VIEWPORT viewPort);
+    void SetScissorRect(const D3D12_RECT scissorRect);
+    void SetFullScreen(const bool fullScreen);
     HWND GetWindowHandle();
     Microsoft::WRL::ComPtr<ID3D12Device> GetDevice();
     Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList> GetCommandList();
@@ -57,14 +57,14 @@ public:
     void EndDraw();
 
     std::vector<DXGI_MODE_DESC> GetDisplayModes();
-    bool CompileShaders(std::wstring fileName, std::string& errorMsg);
-    bool CompileVertexShader(std::wstring vsFileName, std::string& errorMsg);
-    bool CompileGeometryShader(std::wstring vsFileName, std::string& errorMsg);
-    bool CompilePixelShader(std::wstring vsFileName, std::string& errorMsg);
+    bool CompileShaders(const std::wstring& fileName, std::string& errorMsg);
+    bool CompileVertexShader(const std::wstring& vsFileName, std::string& errorMsg);
+    bool CompileGeometryShader(const std::wstring& vsFileName, std::string& errorMsg);
+    bool CompilePixelShader(const std::wstring& vsFileName, std::string& errorMsg);
 
     void CreatePipelineState(SkyBox* skyBox);
     void CreatePipelineState(Grid* grid);
-    void CreatePipelineState(Scene* scene, bool wireFrame);
+    void CreatePipelineState(Scene* scene, const bool wireFrame);
 
 private:
     void EnableDebugLayer();

--- a/DX12Engine/Scene.h
+++ b/DX12Engine/Scene.h
@@ -29,29 +29,29 @@ public:
 	Scene(Microsoft::WRL::ComPtr<ID3D12Device> device);
 	~Scene();
 
-	virtual void AddGPUBuffer(Microsoft::WRL::ComPtr<ID3D12Resource> buffer);
-	virtual Microsoft::WRL::ComPtr<ID3DBlob> GetVertexShader();
-	virtual Microsoft::WRL::ComPtr<ID3DBlob> GetPixelShader();
+	virtual void AddGPUBuffer(const Microsoft::WRL::ComPtr<ID3D12Resource>& buffer) override;
+	virtual Microsoft::WRL::ComPtr<ID3DBlob> GetVertexShader() const override;
+	virtual Microsoft::WRL::ComPtr<ID3DBlob> GetPixelShader() const override;
+	virtual Microsoft::WRL::ComPtr<ID3D12RootSignature> GetRootSignature() override;			//Should be const conceptually; see notes in .cpp
 	bool CompileVertexShader(const std::wstring& fileName, std::string& errorMsg);
 	bool CompileGeometryShader(const std::wstring& fileName, std::string& errorMsg);
 	bool CompilePixelShader(const std::wstring& fileName, std::string& errorMsg);
-	virtual Microsoft::WRL::ComPtr<ID3D12RootSignature> GetRootSignature();
-	void AddMaterial(unsigned int materialId, RoughMetallicMaterial material);
-	void AddTexture(unsigned int textureId, Microsoft::WRL::ComPtr<ID3D12Resource> texture);
-	void AddSampler(unsigned int samplerId, D3D12_SAMPLER_DESC samplerDesc);
-	void AddLight(unsigned int lightId, Light light);
-	void AddMesh(Mesh mesh);
+	void AddMaterial(const unsigned int materialId, const RoughMetallicMaterial&& material);
+	void AddTexture(const unsigned int textureId, Microsoft::WRL::ComPtr<ID3D12Resource> texture);
+	void AddSampler(const unsigned int samplerId, D3D12_SAMPLER_DESC samplerDesc);
+	void AddLight(const unsigned int lightId, const Light&& light);
+	void AddMesh(const Mesh&& mesh);
 	
 	void SetCamera(const Camera& camera);
-	void SetMeshConstants(unsigned int meshId, MeshConstants meshConstant);
-	void SetRenderMode(int renderMode);
-	void SetLight(unsigned int lightId, Light light);
+	void SetMeshConstants(const unsigned int meshId, MeshConstants meshConstant);
+	void SetRenderMode(const int renderMode);
+	void SetLight(const unsigned int lightId, Light light);
 	void SetCubeMapTexture(Microsoft::WRL::ComPtr<ID3D12Resource> cubeMapTexture);
 	
-	float GetSceneRadius();
+	float GetSceneRadius() const;
 
 	Microsoft::WRL::ComPtr<ID3D12RootSignature> CreateRootSignature();
-	void Draw(ID3D12GraphicsCommandList* commandList);
+	void Draw(ID3D12GraphicsCommandList* commandList) override;									//Should be const conceptually; see notes in .cpp
 	void SetupNode(SceneNode* node, DirectX::XMFLOAT4X4 parentMtx);
 	void DrawNode(SceneNode* node, ID3D12GraphicsCommandList* commandList, DirectX::XMFLOAT4X4 parentMtx);
 	void DrawMesh(const Mesh& mesh, ID3D12GraphicsCommandList* commandList);
@@ -60,7 +60,7 @@ protected:
 	virtual void SetUpRootSignature(ID3D12GraphicsCommandList* commandList);
 
 	void AddFrameConstantsBuffer();
-	void SetRootSignature(ID3D12GraphicsCommandList* commandList, unsigned int meshId);
+	void SetRootSignature(ID3D12GraphicsCommandList* commandList, const unsigned int meshId);
 	void UpdateConstants(FrameConstants frameConstants);
 
 	const unsigned int MESH_CONSTANTS_N_DESCRIPTORS = 100;	// Mesh constants descriptors goes from 0 to 15 in the CBV_SRV_UAV descriptor heap (maximum 15 mesh)

--- a/DX12Engine/SkyBox.cpp
+++ b/DX12Engine/SkyBox.cpp
@@ -73,12 +73,12 @@ void SkyBox::SetCubeMapTexture(Microsoft::WRL::ComPtr<ID3D12Resource> cubeMapTex
     m_device->CreateShaderResourceView(m_cubeMapTexture.Get(), &srvDesc, m_CBVSRVDescriptorHeap->GetCPUDescriptorHandleForHeapStart());
 }
 
-ComPtr<ID3DBlob> SkyBox::GetVertexShader()
+ComPtr<ID3DBlob> SkyBox::GetVertexShader() const
 {
     return m_vertexShader;
 }
 
-ComPtr<ID3DBlob> SkyBox::GetPixelShader()
+ComPtr<ID3DBlob> SkyBox::GetPixelShader() const
 {
     return m_pixelShader;
 }

--- a/DX12Engine/SkyBox.h
+++ b/DX12Engine/SkyBox.h
@@ -19,13 +19,13 @@ public:
 	~SkyBox();
 	void Init(Microsoft::WRL::ComPtr<ID3D12Device> device, Microsoft::WRL::ComPtr<ID3D12CommandQueue> commandQueue);
 	void SetCubeMapTexture(Microsoft::WRL::ComPtr<ID3D12Resource> cubeMapTexture);
-	Microsoft::WRL::ComPtr<ID3DBlob> GetVertexShader();
-	Microsoft::WRL::ComPtr<ID3DBlob> GetPixelShader();
-	Microsoft::WRL::ComPtr<ID3D12RootSignature> GetRootSignature();
+	Microsoft::WRL::ComPtr<ID3DBlob> GetVertexShader() const override;
+	Microsoft::WRL::ComPtr<ID3DBlob> GetPixelShader() const override;
+	Microsoft::WRL::ComPtr<ID3D12RootSignature> GetRootSignature() override;
 	void SetCamera(const Camera& camera);
 	void SetFrameConstants(FrameConstants frameConstants);
 	void SetSkyBoxConstants(SkyBoxConstants meshConstants);
-	void Draw(ID3D12GraphicsCommandList* commandList);
+	void Draw(ID3D12GraphicsCommandList* commandList) override;
 
 protected:
 	const unsigned int SKYBOX_SPHERE_SUBDIVISION = 1; // Number of subdivision to generate the skybox sphere

--- a/DX12Engine/SwapChain.cpp
+++ b/DX12Engine/SwapChain.cpp
@@ -25,7 +25,7 @@ void SwapChain::Create(Microsoft::WRL::ComPtr<ID3D12Device> device, DXGI_SWAP_CH
     ThrowIfFailed(device->CreateDescriptorHeap(&heapDesc, IID_PPV_ARGS(&m_rtvDescriptorHeap)), "Cannot create RTV descriptor heap");
 }
 
-void SwapChain::Resize(UINT width, UINT height)
+void SwapChain::Resize(const UINT width, const UINT height)
 {
     m_swapChainDesc.Width = width;
     m_swapChainDesc.Height = height;
@@ -34,7 +34,7 @@ void SwapChain::Resize(UINT width, UINT height)
     CreateRenderTargetViews();
 }
 
-void SwapChain::SetFullScreen(bool fullScreen)
+void SwapChain::SetFullScreen(const bool fullScreen)
 {
     if (m_isFullScreen == fullScreen) return;
     m_isFullScreen = fullScreen;

--- a/DX12Engine/SwapChain.h
+++ b/DX12Engine/SwapChain.h
@@ -13,8 +13,8 @@ public:
     ~SwapChain() = default;
 
     void Create(Microsoft::WRL::ComPtr<ID3D12Device> device, DXGI_SWAP_CHAIN_DESC1 swapChainDesc, DXGI_SWAP_CHAIN_FULLSCREEN_DESC swapChainFullScreenDesc, HWND hWnd, Microsoft::WRL::ComPtr<ID3D12CommandQueue> commandQueue);
-    void Resize(UINT width, UINT height);
-    void SetFullScreen(bool fullScreen);
+    void Resize(const UINT width, const UINT height);
+    void SetFullScreen(const bool fullScreen);
 
     ID3D12Resource* GetCurrentBackBuffer() const;
     D3D12_CPU_DESCRIPTOR_HANDLE GetCurrentBackBufferView() const;

--- a/DX12Engine/Texture.cpp
+++ b/DX12Engine/Texture.cpp
@@ -3,7 +3,7 @@
 #include <DDSTextureLoader.h>
 #include <WICTextureLoader.h>
 
-void CreateTextureFromMemory(ID3D12Device* device, ID3D12CommandQueue* commandQueue, const uint8_t* textureData, size_t textureDataSize, ID3D12Resource** texture)
+void CreateTextureFromMemory(ID3D12Device* device, ID3D12CommandQueue* commandQueue, const uint8_t* textureData, const size_t textureDataSize, ID3D12Resource** texture)
 {
 	DirectX::ResourceUploadBatch resourceUploadBatch(device);
 	resourceUploadBatch.Begin();
@@ -14,7 +14,7 @@ void CreateTextureFromMemory(ID3D12Device* device, ID3D12CommandQueue* commandQu
 	//auto desc = (*texture)->GetDesc();
 }
 
-void CreateTextureFromFile(ID3D12Device* device, ID3D12CommandQueue* commandQueue, std::string fileName, ID3D12Resource** texture)
+void CreateTextureFromFile(ID3D12Device* device, ID3D12CommandQueue* commandQueue, const std::string& fileName, ID3D12Resource** texture)
 {
 	DirectX::ResourceUploadBatch resourceUploadBatch(device);
 	resourceUploadBatch.Begin();
@@ -25,7 +25,7 @@ void CreateTextureFromFile(ID3D12Device* device, ID3D12CommandQueue* commandQueu
 	//auto desc = (*texture)->GetDesc();
 }
 
-void CreateTextureFromDDSFile(ID3D12Device* device, ID3D12CommandQueue* commandQueue, std::string fileName, ID3D12Resource** texture)
+void CreateTextureFromDDSFile(ID3D12Device* device, ID3D12CommandQueue* commandQueue, const std::string& fileName, ID3D12Resource** texture)
 {
 	DirectX::ResourceUploadBatch resourceUploadBatch(device);
 	resourceUploadBatch.Begin();

--- a/DX12Engine/Texture.h
+++ b/DX12Engine/Texture.h
@@ -2,6 +2,6 @@
 
 #include "DXUtil.h"
 
-void CreateTextureFromMemory(ID3D12Device* device, ID3D12CommandQueue* commandQueue, const uint8_t* textureData, size_t textureDataSize, ID3D12Resource** texture);
-void CreateTextureFromFile(ID3D12Device* device, ID3D12CommandQueue* commandQueue, std::string fileName, ID3D12Resource** texture);
-void CreateTextureFromDDSFile(ID3D12Device* device, ID3D12CommandQueue* commandQueue, std::string fileName, ID3D12Resource** texture);
+void CreateTextureFromMemory(ID3D12Device* device, ID3D12CommandQueue* commandQueue, const uint8_t* textureData, const size_t textureDataSize, ID3D12Resource** texture);
+void CreateTextureFromFile(ID3D12Device* device, ID3D12CommandQueue* commandQueue, const std::string& fileName, ID3D12Resource** texture);
+void CreateTextureFromDDSFile(ID3D12Device* device, ID3D12CommandQueue* commandQueue, const std::string& fileName, ID3D12Resource** texture);

--- a/DX12Engine/Timer.cpp
+++ b/DX12Engine/Timer.cpp
@@ -40,7 +40,7 @@ double Timer::tick()
 	return m_deltaTime;
 }
 
-double Timer::total()
+double Timer::total() const 
 {
 	return (m_totalTime - m_stopTime) * m_secondsForCount;
 }

--- a/DX12Engine/Timer.h
+++ b/DX12Engine/Timer.h
@@ -26,7 +26,7 @@ public:
 	void start();
 
 	/** Return the seconds elapsed from the call to the constructor or the last call to reset() */
-	double total();
+	double total() const;
 
 private:
 	__int64  m_countsForSecond;	// Timer frequency: how many counts per seconds

--- a/DX12Engine/ViewerApp.cpp
+++ b/DX12Engine/ViewerApp.cpp
@@ -223,7 +223,7 @@ void ViewerApp::InitWIC()
     DEBUG_LOG("WIC initialized");
 }
 
-void ViewerApp::SetFullScreen(bool fullScreen)
+void ViewerApp::SetFullScreen(const bool fullScreen)
 {
     m_renderer->SetFullScreen(fullScreen);
 }
@@ -251,7 +251,7 @@ void ViewerApp::OnAppMinimized()
     m_appState.isAppMinimized = true;
 }
 
-void ViewerApp::OnResize(UINT width, UINT height)
+void ViewerApp::OnResize(const UINT width, const UINT height)
 {
     float scaleGUI = static_cast<float>(m_appState.screenWidth) / static_cast<float>(m_clientWidth);
 
@@ -269,7 +269,7 @@ void ViewerApp::OnResize(UINT width, UINT height)
     //m_gui.RecreateDeviceObjects();
 };
 
-void ViewerApp::OnMouseMove(WPARAM btnState, int x, int y)
+void ViewerApp::OnMouseMove(const WPARAM btnState, const int x, const int y)
 {
     if (btnState == MK_LBUTTON) 
     {
@@ -291,13 +291,13 @@ void ViewerApp::OnMouseMove(WPARAM btnState, int x, int y)
     m_lastMousePosY = y;
 }; 
 
-void ViewerApp::OnMouseDown(WPARAM btnState, int x, int y)
+void ViewerApp::OnMouseDown(const WPARAM btnState, const int x, const int y)
 {};
 
-void ViewerApp::OnMouseUp(WPARAM btnState, int x, int y)
+void ViewerApp::OnMouseUp(const WPARAM btnState, const int x, const int y)
 {};
 
-void ViewerApp::OnKeyDown(WPARAM wParam)
+void ViewerApp::OnKeyDown(const WPARAM wParam)
 {    
     // Handle camera movements
     if (wParam == VK_KEY_W) m_camera->moveForward(m_cameraStep);

--- a/DX12Engine/ViewerApp.h
+++ b/DX12Engine/ViewerApp.h
@@ -48,7 +48,7 @@ public:
 	ViewerApp(const HINSTANCE& m_hInstance);
 	~ViewerApp();
 	int Run();
-	void SetFullScreen(bool fullScreen);
+	void SetFullScreen(const bool fullScreen);
 	
 	/** Message procedure called from the window callback */
 	virtual LRESULT WndMsgProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
@@ -66,11 +66,11 @@ protected:
 	virtual void OnEnterSizeMove();
 	virtual void OnExitSizeMove();
 	virtual void OnAppMinimized();
-	virtual void OnResize(UINT width, UINT height);
-	virtual void OnMouseMove(WPARAM btnState, int x, int y);
-	virtual void OnMouseDown(WPARAM btnState, int x, int y);
-	virtual void OnMouseUp(WPARAM btnState, int x, int y);
-	virtual void OnKeyDown(WPARAM btnState);
+	virtual void OnResize(const UINT width, const UINT height);
+	virtual void OnMouseMove(const WPARAM btnState, const int x, const int y);
+	virtual void OnMouseDown(const WPARAM btnState, const int x, const int y);
+	virtual void OnMouseUp(const WPARAM btnState, const int x, const int y);
+	virtual void OnKeyDown(const WPARAM btnState);
 	virtual void OnDestroy();
 	virtual void OnUpdate();
 	virtual void OnDraw();

--- a/DX12Engine/imgui.ini
+++ b/DX12Engine/imgui.ini
@@ -34,8 +34,8 @@ Size=247,48
 Collapsed=0
 
 [Window][Statistics]
-Pos=1679,27
-Size=230,93
+Pos=838,4
+Size=394,116
 Collapsed=0
 
 [Window][Controls]
@@ -1289,7 +1289,7 @@ Size=700,450
 Collapsed=0
 
 [Window][Shader Editor]
-Pos=1395,126
+Pos=1280,172
 Size=519,693
 Collapsed=0
 
@@ -1299,7 +1299,7 @@ Size=700,450
 Collapsed=0
 
 [Window][Logs]
-Pos=1401,825
+Pos=1279,501
 Size=518,188
 Collapsed=0
 
@@ -1430,6 +1430,16 @@ Collapsed=0
 
 [Window][title##filebrowser_1394034527896]
 Pos=612,283
+Size=700,450
+Collapsed=0
+
+[Window][title##filebrowser_2785274547864]
+Pos=290,160
+Size=700,450
+Collapsed=0
+
+[Window][title##filebrowser_2237130026648]
+Pos=610,283
 Size=700,450
 Collapsed=0
 

--- a/DX12Engine/shaders.cpp
+++ b/DX12Engine/shaders.cpp
@@ -4,7 +4,7 @@
 
 #include "using_directives.h"
 
-bool CompileShaders(std::wstring fileName, std::string& errorMsg, Microsoft::WRL::ComPtr<ID3DBlob>& vertexShader, Microsoft::WRL::ComPtr<ID3DBlob>& pixelShader)
+bool CompileShaders(const std::wstring fileName, std::string& errorMsg, Microsoft::WRL::ComPtr<ID3DBlob>& vertexShader, Microsoft::WRL::ComPtr<ID3DBlob>& pixelShader)
 {
 
 #if defined(_DEBUG)
@@ -32,7 +32,7 @@ bool CompileShaders(std::wstring fileName, std::string& errorMsg, Microsoft::WRL
         return true;
 }
 
-bool CompileVertexShader(std::wstring vsFileName, std::string& errorMsg, ComPtr<ID3DBlob>& vertexShader)
+bool CompileVertexShader(const std::wstring vsFileName, std::string& errorMsg, ComPtr<ID3DBlob>& vertexShader)
 {
 #if defined(_DEBUG)
     UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;
@@ -62,12 +62,12 @@ bool CompileVertexShader(std::wstring vsFileName, std::string& errorMsg, ComPtr<
     return true;
 }
 
-bool CompileGeometryShader(std::wstring vsFileName, std::string& errorMsg, ComPtr<ID3DBlob>& geometryShader)
+bool CompileGeometryShader(const std::wstring vsFileName, std::string& errorMsg, ComPtr<ID3DBlob>& geometryShader)
 {
     return true;
 }
 
-bool CompilePixelShader(std::wstring psFileName, std::string& errorMsg, ComPtr<ID3DBlob>& pixelShader)
+bool CompilePixelShader(const std::wstring psFileName, std::string& errorMsg, ComPtr<ID3DBlob>& pixelShader)
 {
 #if defined(_DEBUG)
     UINT compileFlags = D3DCOMPILE_DEBUG | D3DCOMPILE_SKIP_OPTIMIZATION;

--- a/DX12Engine/shaders.h
+++ b/DX12Engine/shaders.h
@@ -2,8 +2,8 @@
 
 #include "DXUtil.h"
 
-bool CompileShaders(std::wstring fileName, std::string& errorMsg, Microsoft::WRL::ComPtr<ID3DBlob>& vertexShader, Microsoft::WRL::ComPtr<ID3DBlob>& pixelShader);
+bool CompileShaders(const std::wstring fileName, std::string& errorMsg, Microsoft::WRL::ComPtr<ID3DBlob>& vertexShader, Microsoft::WRL::ComPtr<ID3DBlob>& pixelShader);
 
-bool CompileVertexShader(std::wstring vsFileName, std::string& errorMsg, Microsoft::WRL::ComPtr<ID3DBlob>& vertexShader);
-bool CompileGeometryShader(std::wstring vsFileName, std::string& errorMsg, Microsoft::WRL::ComPtr<ID3DBlob>& geometryShader);
-bool CompilePixelShader(std::wstring psFileName, std::string& errorMsg, Microsoft::WRL::ComPtr<ID3DBlob>& pixelShader);
+bool CompileVertexShader(const std::wstring vsFileName, std::string& errorMsg, Microsoft::WRL::ComPtr<ID3DBlob>& vertexShader);
+bool CompileGeometryShader(const std::wstring vsFileName, std::string& errorMsg, Microsoft::WRL::ComPtr<ID3DBlob>& geometryShader);
+bool CompilePixelShader(const std::wstring psFileName, std::string& errorMsg, Microsoft::WRL::ComPtr<ID3DBlob>& pixelShader);


### PR DESCRIPTION
As far as I noticed, this makes your rendering loop faster.

Declaring parameters const should enable more optimization by the compiler. It also makes your code more readable as the reader knows what could and could not change in the function body.
Moreover, passing some parameters by reference -when possible- avoids unnecessary copies, especially those that may impact performance heavily like std::string or std::wstring copies.

In the long run, this should help with performance.